### PR TITLE
Create a alpine-based slim version of the rsync image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 # initially created by https://github.com/Duske - thank you!
 MAINTAINER Eugen Mayer <eugen.mayer@kontextwork.de>
-RUN apk --update add rsync
+RUN apk --update add rsync && rm -f /etc/rsyncd.conf
 
 EXPOSE 873
 

--- a/run
+++ b/run
@@ -16,7 +16,10 @@ mkdir -p $VOLUME
 
 chown "${OWNER}:${GROUP}" "${VOLUME}"
 
-[ -f /etc/rsyncd.conf ] || cat <<EOF > /etc/rsyncd.conf
+# updated condition if rsyncd.conf exist
+if [ -f /etc/rsyncd.conf ];
+then
+	cat <<EOF >> /etc/rsyncd.conf
 uid = ${OWNER}
 gid = ${GROUP}
 use chroot = yes
@@ -29,5 +32,6 @@ reverse lookup = no
     path = ${VOLUME}
     comment = docker volume
 EOF
+fi
 
 exec /usr/bin/rsync --no-detach --daemon --config="/etc/rsyncd.conf" "$@"

--- a/run
+++ b/run
@@ -17,12 +17,11 @@ mkdir -p $VOLUME
 chown "${OWNER}:${GROUP}" "${VOLUME}"
 
 # updated condition if rsyncd.conf exist
-if [ -f /etc/rsyncd.conf ];
-then
-	cat <<EOF >> /etc/rsyncd.conf
+[ -f /etc/rsyncd.conf ] || cat <<EOF > /etc/rsyncd.conf
+pid file = /var/run/rsyncd.pid
 uid = ${OWNER}
 gid = ${GROUP}
-use chroot = yes
+use chroot = no
 log file = /dev/stdout
 reverse lookup = no
 [volume]
@@ -32,6 +31,5 @@ reverse lookup = no
     path = ${VOLUME}
     comment = docker volume
 EOF
-fi
 
 exec /usr/bin/rsync --no-detach --daemon --config="/etc/rsyncd.conf" "$@"


### PR DESCRIPTION
To slim down the image we want it to be based on alpine linux. 
Note: `chroot` is disabled in `/etc/rsyncd.conf` in order to work with alpine linux. Since this image destined for local development only this is okay. (See [this thread](https://github.com/EugenMayer/docker-sync/issues/28))
