### PR TITLE
[BUGFIX] disable munge symlinks

### DIFF
--- a/run
+++ b/run
@@ -36,6 +36,7 @@ gid = ${GROUP}
 use chroot = no
 log file = /dev/stdout
 reverse lookup = no
+munge symlinks = no
 [volume]
     hosts deny = *
     hosts allow = ${ALLOW}


### PR DESCRIPTION
To resolve EugenMayer/docker-sync#85

Since we're using `use chroot = no`,  `munge symlinks` is activated by default (see [this page](https://download.samba.org/pub/rsync/rsyncd.conf.html)).
This can lead to messed up symlinks, so we disable it explicitly.
