### PR TITLE
Entrypoint.sh dies when missing process

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,7 +78,7 @@ if [ "$1" == 'supervisord' ]; then
 	if [ -f '/var/run/rsyncd.pid' ]; then
 	  PID=`cat /var/run/rsyncd.pid`
 	  echo "pidfile exsits with pid $PID, killing and removing it - restarting further on"
-	  killall $PID > /dev/null 2>&1
+	  killall $PID > /dev/null 2>&1 || echo "Process was not running"
 	  rm /var/run/rsyncd.pid
 	fi
 


### PR DESCRIPTION
Prevented killall from prematurely ending entrypoint.sh script when the process corresponding to the pidfile is not running.